### PR TITLE
Refine dependency verification

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from typing import List
 
 from modules.base import Module, Finding
+import modules  # noqa: F401  # populate Module.registry
 from utils.logger import get_logger
 from utils.output import write_json
+from utils.deps import DependencyError, check_dependencies
 
 logger = get_logger()
 
@@ -57,6 +59,12 @@ def cli() -> None:
 
     logger.info("🎯 Target: %s", args.target)
     logger.info("🧰 Tools : %s", ", ".join(args.tools))
+
+    try:
+        check_dependencies(args.tools)
+    except DependencyError as exc:
+        logger.error("❌ %s", exc)
+        raise SystemExit(1)
 
     findings = pipeline(args.target, args.tools)
     write_json(findings, args.out)

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,11 @@
+from .subfinder import Subfinder
+from .httpx import Httpx
+from .nmap_ import Nmap
+from .testssl import TestSSL
+
+__all__ = [
+    "Subfinder",
+    "Httpx",
+    "Nmap",
+    "TestSSL",
+]

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.deps import DependencyError, check_dependencies
+
+
+def test_missing_binary(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: False)
+    with pytest.raises(DependencyError):
+        check_dependencies(["httpx"])
+
+
+def test_dependency_present(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: "/bin/true")
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    check_dependencies(["httpx"])

--- a/utils/deps.py
+++ b/utils/deps.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Utility helpers for verifying external dependencies."""
+
+import os
+import shutil
+from pathlib import Path
+from typing import Iterable, List
+
+from modules.base import Module
+from utils.logger import get_logger
+
+logger = get_logger()
+
+_BINARIES = {
+    "subfinder": "subfinder",
+    "httpx": "httpx",
+    "nmap": "nmap",
+    "testssl": "testssl.sh",
+}
+
+
+class DependencyError(RuntimeError):
+    """Raised when one or more dependencies are missing."""
+
+    def __init__(self, missing: Iterable[str]):
+        self.missing = sorted(missing)
+        msg = f"Missing required binaries: {', '.join(self.missing)}"
+        super().__init__(msg)
+
+
+def _is_executable(path: str) -> bool:
+    """Return ``True`` if *path* points to an executable."""
+
+    p = Path(path)
+    if p.is_absolute():
+        return p.exists() and os.access(p, os.X_OK)
+
+    located = shutil.which(path)
+    return bool(located and os.access(located, os.X_OK))
+
+
+def check_dependencies(selected: Iterable[str]) -> None:
+    """Ensure all required external binaries are present and executable."""
+
+    logger.info("🔍 Checking dependencies …")
+    missing = []
+    for tool in selected:
+        binary = _BINARIES.get(tool)
+        if not binary:
+            continue
+        cls = Module.registry.get(tool)
+        if not cls:
+            continue
+        path = cls.bin(binary)
+        if not _is_executable(path):
+            missing.append(binary)
+
+    if missing:
+        raise DependencyError(missing)
+
+    logger.info("✅ All dependencies available")


### PR DESCRIPTION
## Summary
- make dependency checks stricter and more professional
- raise a custom `DependencyError`
- handle new exception in the CLI
- test both missing and present binary cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468f2f3374832ab290aafe77522d89