### PR TITLE
Add pipelined recon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * Structured JSON output with optional HTML or PDF reports
 * Docker container and AWS Lambda compatible
 * Extensible plugin system for custom modules
+* Opt-in pipeline mode to feed Subfinder → Httpx → Nuclei
 
 ---
 
@@ -50,7 +51,7 @@ git clone https://github.com/psychevus/pentest-toolkit.git
 cd pentest-toolkit
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt -r requirements-dev.txt
-python main.py example.com
+python main.py example.com --pipeline
 ```
 
 ### Docker

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -36,6 +36,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     webhook = event.get("webhook")
     webhook_type = event.get("webhook_type", "slack")
     auto_install = event.get("auto_install", False)
+    pipeline_mode = event.get("pipeline", False)
 
     out_dir = Path("/tmp/output")
 
@@ -45,7 +46,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         logger.error("❌ %s", exc)
         raise RuntimeError(str(exc))
 
-    findings = pipeline(target, tools)
+    findings = pipeline(target, tools, use_pipeline=pipeline_mode)
     json_path = write_json(findings, out_dir)
 
     if report == "html":

--- a/main.py
+++ b/main.py
@@ -3,8 +3,9 @@
 Pentest-Toolkit
 ===============
 
-Modular reconnaissance pipeline:
-subfinder → httpx → nmap → testssl.sh
+Modular reconnaissance pipeline. With ``--pipeline`` enabled, results from
+Subfinder feed into Httpx which then drive Nuclei, with optional TestSSL and
+Nmap scans on discovered hosts.
 """
 
 from __future__ import annotations
@@ -26,8 +27,12 @@ load_plugins()
 logger = get_logger()
 
 
-def pipeline(target: str, selected: List[str]) -> List[Finding]:
+def pipeline(target: str, selected: List[str], use_pipeline: bool = False) -> List[Finding]:
     findings: List[Finding] = []
+
+    # Data passed between modules
+    hosts: List[str] = [target]
+    urls: List[str] = []
 
     for tool_name in selected:
         tool_cls = Module.registry.get(tool_name)
@@ -35,7 +40,23 @@ def pipeline(target: str, selected: List[str]) -> List[Finding]:
             logger.warning("⚠️ Unknown tool '%s' – skipping", tool_name)
             continue
         try:
-            findings.extend(tool_cls().run(target))
+            if use_pipeline and tool_name == "subfinder":
+                res = tool_cls().run(target)
+                findings.extend(res)
+                hosts = [f.data.get("host") for f in res if f.data.get("host")]
+            elif use_pipeline and tool_name == "httpx":
+                res = tool_cls().run("\n".join(hosts))
+                findings.extend(res)
+                urls = [f.data.get("url") for f in res if f.data.get("url")]
+                hosts = [f.data.get("host") or f.data.get("ip") for f in res if f.data.get("host") or f.data.get("ip")]
+            elif use_pipeline and tool_name == "nuclei":
+                res = tool_cls().run("\n".join(urls))
+                findings.extend(res)
+            elif use_pipeline and tool_name in {"nmap", "testssl"}:
+                for h in hosts:
+                    findings.extend(tool_cls().run(h))
+            else:
+                findings.extend(tool_cls().run(target))
         except Exception as exc:  # noqa: BLE001
             logger.error("%s error: %s", tool_name, exc)
 
@@ -79,6 +100,11 @@ def cli() -> None:
         default="slack",
         help="Webhook service type (default: slack)",
     )
+    parser.add_argument(
+        "--pipeline",
+        action="store_true",
+        help="Chain tool output into the next module",
+    )
     args = parser.parse_args()
 
     logger.info("🎯 Target: %s", args.target)
@@ -90,7 +116,7 @@ def cli() -> None:
         logger.error("❌ %s", exc)
         raise SystemExit(1)
 
-    findings = pipeline(args.target, args.tools)
+    findings = pipeline(args.target, args.tools, use_pipeline=args.pipeline)
     write_json(findings, args.out)
     if args.report == "html":
         write_html(findings, args.out)

--- a/modules/nuclei.py
+++ b/modules/nuclei.py
@@ -15,12 +15,13 @@ class Nuclei(Module):
 
     def run(self, target: str) -> List[Finding]:
         logger.info("\u2694\ufe0f nuclei \u2026")
-        cmd = f"{self.bin('nuclei')} -u {shlex.quote(target)} -json"
+        cmd = f"{self.bin('nuclei')} -json -l -"
         try:
             proc = subprocess.run(
                 shlex.split(cmd),
-                capture_output=True,
+                input=target,
                 text=True,
+                capture_output=True,
                 timeout=self.TIMEOUT,
                 check=True,
             )

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -14,7 +14,7 @@ def test_lambda_handler(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(
         lambda_function,
         "pipeline",
-        lambda target, tools: [],
+        lambda target, tools, use_pipeline=False: [],
     )
     monkeypatch.setattr(
         lambda_function,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,16 +14,19 @@ def test_pipeline(monkeypatch):
     monkeypatch.setattr(Module, 'registry', {})
     monkeypatch.setattr(main.Module, 'registry', Module.registry)
 
+    captured = {}
+
     class A(Module):
-        name = 'a'
+        name = 'subfinder'
         def run(self, target: str):
-            return [Finding(tool=self.name, data={'a': target})]
+            return [Finding(tool=self.name, data={'host': 'a.example'})]
 
     class B(Module):
-        name = 'b'
+        name = 'httpx'
         def run(self, target: str):
-            return [Finding(tool=self.name, data={'b': target})]
-    results = pipeline('example.com', ['a', 'b'])
+            captured['input'] = target
+            return [Finding(tool=self.name, data={'url': f'https://{target}'})]
+
+    results = pipeline('example.com', ['subfinder', 'httpx'], use_pipeline=True)
+    assert captured['input'] == 'a.example'
     assert len(results) == 2
-    assert results[0].data == {'a': 'example.com'}
-    assert results[1].data == {'b': 'example.com'}


### PR DESCRIPTION
## Summary
- allow linking tool output with `--pipeline`
- route Subfinder hosts -> Httpx -> Nuclei
- optionally use discovered hosts with TestSSL and Nmap
- document pipeline mode in README
- update tests for new behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842850982c832aa268dfa49eeb4a75