### PR TITLE
Align default module order with architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@
 
 ## Features
 
-* Wraps `subfinder`, `httpx`, `nmap`, `testssl.sh` and `nuclei` behind one interface
+* Wraps `subfinder`, `httpx`, `nuclei`, `nmap`, `testssl.sh` behind one interface
 * Structured JSON output with optional HTML or PDF reports
 * Docker container and AWS Lambda compatible
 * Extensible plugin system for custom modules
-* Opt-in pipeline mode to feed Subfinder → Httpx → Nuclei
+* Opt-in pipeline mode to feed Subfinder → Httpx → Nuclei → Nmap → TestSSL
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ Pentest-Toolkit
 ===============
 
 Modular reconnaissance pipeline. With ``--pipeline`` enabled, results from
-Subfinder feed into Httpx which then drive Nuclei, with optional TestSSL and
-Nmap scans on discovered hosts.
+Subfinder feed into Httpx which then drive Nuclei, followed by Nmap and
+TestSSL scans on discovered hosts.
 """
 
 from __future__ import annotations
@@ -76,7 +76,11 @@ def cli() -> None:
         "--tools",
         nargs="+",
         default=list(Module.registry.keys()),
-        help="Tools to run (default: all)",
+        help=(
+            "Tools to run in order (default: "
+            + " ".join(Module.registry.keys())
+            + ")"
+        ),
     )
     parser.add_argument(
         "--out",

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,13 +1,13 @@
 from .subfinder import Subfinder
 from .httpx import Httpx
+from .nuclei import Nuclei
 from .nmap_ import Nmap
 from .testssl import TestSSL
-from .nuclei import Nuclei
 
 __all__ = [
     "Subfinder",
     "Httpx",
+    "Nuclei",
     "Nmap",
     "TestSSL",
-    "Nuclei",
 ]


### PR DESCRIPTION
## Summary
- run Nuclei before Nmap by reordering the default module list
- describe new pipeline order in help text
- clarify pipeline order in README

## Testing
- `pytest -q`
