### PR TITLE
Add timestamp suffix for module outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ trivial.
 [
   { "type": "subdomain", "host": "api.example.co.uk", "ip": "93.184.216.34" },
   { "type": "httpx", "url": "https://api.example.co.uk", "status": 200, "tls": true },
-  { "nmap_xml": "output/nmap_2025-05-19T11-31-12.xml" },
-  { "testssl_json": "output/testssl_api.example.co.uk.json" }
+  { "nmap_xml": "output/nmap_api.example.co.uk_20250519-1131.xml" },
+  { "testssl_json": "output/testssl_api.example.co.uk_20250519-1131.json" }
 ]
 ```
 
-Results are stored in `output/` with ISO timestamps. They can also be pushed to
+Results are stored in `output/` with timestamps. They can also be pushed to
 Slack or Microsoft Teams using `--webhook <url> --webhook-type slack|teams`.
 
 ---

--- a/modules/nmap_.py
+++ b/modules/nmap_.py
@@ -1,11 +1,11 @@
 import shlex
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import List
 
 from utils.logger import get_logger
 from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
 
 logger = get_logger()
 
@@ -16,8 +16,10 @@ class Nmap(Module):
 
     def run(self, target: str) -> List[Finding]:
         logger.info("📡 nmap …")
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".xml") as tmp:
-            out_path = Path(tmp.name)
+        out_dir = Path("output")
+        out_dir.mkdir(exist_ok=True)
+        safe = safe_filename_component(target)
+        out_path = out_dir / f"nmap_{safe}_{timestamp()}.xml"
 
         cmd = f"{self.bin('nmap')} -T4 -sV -oX {out_path} {shlex.quote(target)}"
         try:

--- a/modules/testssl.py
+++ b/modules/testssl.py
@@ -5,6 +5,7 @@ from typing import List
 
 from utils.logger import get_logger
 from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
 
 logger = get_logger()
 
@@ -15,7 +16,8 @@ class TestSSL(Module):
 
     def run(self, target: str) -> List[Finding]:
         logger.info("🔐 testssl.sh …")
-        out_file = Path("output") / f"testssl_{target}.json"
+        safe = safe_filename_component(target)
+        out_file = Path("output") / f"testssl_{safe}_{timestamp()}.json"
         cmd = f"{self.bin('testssl.sh')} --quiet --jsonfile-pretty {out_file} {shlex.quote(target)}"
 
         try:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -40,29 +40,30 @@ def test_httpx(monkeypatch):
 
 
 def test_nmap(monkeypatch, tmp_path: Path):
-    tmp_file = tmp_path / "out.xml"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(nmap_, "timestamp", lambda: "20240101-0000")
 
-    class DummyTmp:
-        name = str(tmp_file)
-        def __enter__(self):
-            tmp_file.touch()
-            return self
-        def __exit__(self, exc_type, exc, tb):
-            pass
+    def fake_run(*a, **kw):
+        out_file = Path("output/nmap_example.com_20240101-0000.xml")
+        out_file.parent.mkdir(exist_ok=True)
+        out_file.touch()
+        return DummyProc()
 
-    monkeypatch.setattr(nmap_.tempfile, "NamedTemporaryFile", lambda delete, suffix: DummyTmp())
-    monkeypatch.setattr(nmap_.subprocess, "run", lambda *a, **kw: DummyProc())
+    monkeypatch.setattr(nmap_.subprocess, "run", fake_run)
     results = nmap_.Nmap().run("example.com")
     assert Path(results[0].data["xml"]).exists()
 
 
 def test_testssl(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(testssl, "timestamp", lambda: "20240101-0000")
+
     def fake_run(*a, **kw):
-        out_file = Path("output/testssl_example.com.json")
+        out_file = Path("output/testssl_example.com_20240101-0000.json")
         out_file.parent.mkdir(exist_ok=True)
         out_file.touch()
         return DummyProc()
+
     monkeypatch.setattr(testssl.subprocess, "run", fake_run)
     results = testssl.TestSSL().run("example.com")
     path = Path(results[0].data["report"])

--- a/utils/output.py
+++ b/utils/output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
@@ -13,9 +14,19 @@ from modules.base import Finding
 logger = get_logger()
 
 
+def timestamp() -> str:
+    """Return a filesystem-safe UTC timestamp."""
+    return datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M")
+
+
+def safe_filename_component(value: str) -> str:
+    """Sanitise *value* so it can be safely used in filenames."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_", value)
+
+
 def write_json(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
     out_dir.mkdir(exist_ok=True)
-    name = f"results_{datetime.now(tz=timezone.utc).isoformat(timespec='seconds')}.json"
+    name = f"results_{timestamp()}.json"
     path = out_dir / name
 
     tmp = path.with_suffix(".tmp")
@@ -60,7 +71,7 @@ def _html_template(findings: List[Finding]) -> str:
 
 def write_html(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
     out_dir.mkdir(exist_ok=True)
-    name = f"report_{datetime.now(tz=timezone.utc).isoformat(timespec='seconds')}.html"
+    name = f"report_{timestamp()}.html"
     path = out_dir / name
 
     tmp = path.with_suffix(".tmp")


### PR DESCRIPTION
## Summary
- add `timestamp()` and `safe_filename_component()` helpers
- generate timestamped output files for `testssl` and `nmap`
- update results/HTML report naming
- adjust unit tests and README examples

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842fe407d0832aa350797cd2108f8e