### PR TITLE
Add resilient webhook notifications

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 
 from modules.base import Module
 from utils.deps import check_dependencies, DependencyError
+import requests
 from utils.logger import get_logger
 from utils.notify import notify_slack, notify_teams
 from utils.output import write_html, write_json, write_pdf
@@ -35,6 +36,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     report = event.get("report")
     webhook = event.get("webhook")
     webhook_type = event.get("webhook_type", "slack")
+    strict_webhook = event.get("strict_webhook", False)
     auto_install = event.get("auto_install", False)
     pipeline_mode = event.get("pipeline", False)
 
@@ -55,9 +57,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         write_pdf(findings, out_dir)
 
     if webhook:
-        if webhook_type == "teams":
-            notify_teams(findings, webhook)
-        else:
-            notify_slack(findings, webhook)
+        try:
+            if webhook_type == "teams":
+                notify_teams(findings, webhook, strict=strict_webhook)
+            else:
+                notify_slack(findings, webhook, strict=strict_webhook)
+        except requests.RequestException as exc:  # noqa: BLE001
+            logger.error("❌ Webhook error: %s", exc)
+            raise RuntimeError(str(exc))
 
     return {"count": len(findings), "json": str(json_path)}

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from typing import List
 
 from modules.base import Module, Finding
 import modules  # noqa: F401  # populate Module.registry
+import requests
 from utils.logger import get_logger
 from utils.output import write_json, write_html, write_pdf
 from utils.notify import notify_slack, notify_teams
@@ -109,6 +110,11 @@ def cli() -> None:
         help="Webhook service type (default: slack)",
     )
     parser.add_argument(
+        "--strict-webhook",
+        action="store_true",
+        help="Exit with error if webhook notification fails",
+    )
+    parser.add_argument(
         "--pipeline",
         action="store_true",
         help="Chain tool output into the next module",
@@ -132,10 +138,14 @@ def cli() -> None:
         write_pdf(findings, args.out)
 
     if args.webhook:
-        if args.webhook_type == "slack":
-            notify_slack(findings, args.webhook)
-        else:
-            notify_teams(findings, args.webhook)
+        try:
+            if args.webhook_type == "slack":
+                notify_slack(findings, args.webhook, strict=args.strict_webhook)
+            else:
+                notify_teams(findings, args.webhook, strict=args.strict_webhook)
+        except requests.RequestException as exc:
+            logger.error("❌ Webhook error: %s", exc)
+            raise SystemExit(1)
 
     logger.info("✅ Finished – %s findings collected", len(findings))
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,5 +1,7 @@
 from modules.base import Finding
 from utils.notify import notify_slack, notify_teams
+import requests
+import pytest
 
 
 def _sample():
@@ -40,3 +42,37 @@ def test_notify_teams(monkeypatch):
     notify_teams(_sample(), "http://example.com")
     assert payloads['url'] == "http://example.com"
     assert "Pentest-Toolkit" in payloads['json']['text']
+
+
+def test_notify_slack_failure(monkeypatch):
+    def boom(url, json, timeout):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr("utils.notify.requests.post", boom)
+    notify_slack(_sample(), "http://bad", strict=False)
+
+
+def test_notify_slack_failure_strict(monkeypatch):
+    def boom(url, json, timeout):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr("utils.notify.requests.post", boom)
+    with pytest.raises(requests.RequestException):
+        notify_slack(_sample(), "http://bad", strict=True)
+
+
+def test_notify_teams_failure(monkeypatch):
+    def boom(url, json, timeout):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr("utils.notify.requests.post", boom)
+    notify_teams(_sample(), "http://bad", strict=False)
+
+
+def test_notify_teams_failure_strict(monkeypatch):
+    def boom(url, json, timeout):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr("utils.notify.requests.post", boom)
+    with pytest.raises(requests.RequestException):
+        notify_teams(_sample(), "http://bad", strict=True)

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -14,17 +14,34 @@ def _render(findings: List[Finding]) -> str:
     return json.dumps([f.asdict() for f in findings], indent=2)
 
 
-def notify_slack(findings: List[Finding], webhook: str) -> None:
-    """Send *findings* to a Slack incoming webhook."""
+def notify_slack(findings: List[Finding], webhook: str, *, strict: bool = False) -> None:
+    """Send *findings* to a Slack incoming webhook.
+
+    If *strict* is ``True`` the underlying ``requests`` exception will be raised
+    to the caller. Otherwise a warning is logged on failure.
+    """
     payload = {"text": f"Pentest-Toolkit results:\n```{_render(findings)}```"}
-    resp = requests.post(webhook, json=payload, timeout=10)
-    resp.raise_for_status()
-    logger.info("📣 Slack notification -> %s", resp.status_code)
+    try:
+        resp = requests.post(webhook, json=payload, timeout=10)
+        resp.raise_for_status()
+        logger.info("📣 Slack notification -> %s", resp.status_code)
+    except requests.RequestException as exc:  # noqa: BLE001
+        logger.warning("⚠️ Slack notification failed: %s", exc)
+        if strict:
+            raise
 
 
-def notify_teams(findings: List[Finding], webhook: str) -> None:
-    """Send *findings* to a Teams incoming webhook."""
+def notify_teams(findings: List[Finding], webhook: str, *, strict: bool = False) -> None:
+    """Send *findings* to a Teams incoming webhook.
+
+    Behaviour mirrors :func:`notify_slack`.
+    """
     payload = {"text": f"Pentest-Toolkit results:\n{_render(findings)}"}
-    resp = requests.post(webhook, json=payload, timeout=10)
-    resp.raise_for_status()
-    logger.info("📣 Teams notification -> %s", resp.status_code)
+    try:
+        resp = requests.post(webhook, json=payload, timeout=10)
+        resp.raise_for_status()
+        logger.info("📣 Teams notification -> %s", resp.status_code)
+    except requests.RequestException as exc:  # noqa: BLE001
+        logger.warning("⚠️ Teams notification failed: %s", exc)
+        if strict:
+            raise


### PR DESCRIPTION
## Summary
- avoid crashes by catching webhook errors
- add `--strict-webhook` CLI option and lambda event parameter
- extend Teams/Slack notifications with `strict` option
- cover webhook error handling in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884324deca0832a903b587372658383