### PR TITLE
Add execution summary with optional flag

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -48,7 +48,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         logger.error("❌ %s", exc)
         raise RuntimeError(str(exc))
 
-    findings = pipeline(target, tools, use_pipeline=pipeline_mode)
+    findings = pipeline(target, tools, use_pipeline=pipeline_mode, show_summary=False)
     json_path = write_json(findings, out_dir)
 
     if report == "html":

--- a/main.py
+++ b/main.py
@@ -13,6 +13,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import List
+import json
+import xml.etree.ElementTree as ET
+
+from rich.console import Console
+from rich.table import Table
 
 from modules.base import Module, Finding
 import modules  # noqa: F401  # populate Module.registry
@@ -28,8 +33,61 @@ load_plugins()
 logger = get_logger()
 
 
-def pipeline(target: str, selected: List[str], use_pipeline: bool = False) -> List[Finding]:
+def _count_nmap_ports(xml_path: str) -> int:
+    try:
+        tree = ET.parse(xml_path)
+    except Exception:
+        return 0
+    count = 0
+    for port in tree.findall(".//port"):
+        state = port.find("state")
+        if state is not None and state.get("state") == "open":
+            count += 1
+    return count
+
+
+def _count_testssl_issues(json_path: str) -> int:
+    try:
+        data = json.loads(Path(json_path).read_text())
+    except Exception:
+        return 0
+    issues = 0
+    for entry in data:
+        sev = str(entry.get("severity", "")).upper()
+        if sev not in {"OK", "INFO"}:
+            issues += 1
+    return issues
+
+
+def _print_summary(summary: dict) -> None:
+    console = Console()
+    table = Table(title="Scan Summary")
+    table.add_column("Metric")
+    table.add_column("Count", justify="right")
+    table.add_row("Subdomains", str(summary["subdomains"]))
+    table.add_row("Live hosts", str(summary["live_hosts"]))
+    table.add_row("Nuclei findings", str(summary["nuclei"]))
+    table.add_row("Open ports", str(summary["open_ports"]))
+    table.add_row("SSL issues", str(summary["ssl_issues"]))
+    console.print(table)
+
+
+def pipeline(
+    target: str,
+    selected: List[str],
+    use_pipeline: bool = False,
+    *,
+    show_summary: bool = False,
+) -> List[Finding]:
     findings: List[Finding] = []
+
+    summary = {
+        "subdomains": 0,
+        "live_hosts": 0,
+        "nuclei": 0,
+        "open_ports": 0,
+        "ssl_issues": 0,
+    }
 
     # Data passed between modules
     hosts: List[str] = [target]
@@ -45,6 +103,7 @@ def pipeline(target: str, selected: List[str], use_pipeline: bool = False) -> Li
                 res = tool_cls().run(target)
                 findings.extend(res)
                 hosts = [f.data.get("host") for f in res if f.data.get("host")]
+                summary["subdomains"] += len(res)
             elif use_pipeline and tool_name == "httpx":
                 res = tool_cls().run("\n".join(hosts))
                 findings.extend(res)
@@ -54,16 +113,30 @@ def pipeline(target: str, selected: List[str], use_pipeline: bool = False) -> Li
                     for f in res
                     if f.data.get("host") or f.data.get("ip")
                 ]
+                summary["live_hosts"] += len(res)
             elif use_pipeline and tool_name == "nuclei":
                 res = tool_cls().run("\n".join(urls))
                 findings.extend(res)
+                summary["nuclei"] += len(res)
             elif use_pipeline and tool_name in {"nmap", "testssl"}:
                 for h in hosts:
-                    findings.extend(tool_cls().run(h))
+                    res = tool_cls().run(h)
+                    findings.extend(res)
+                    if tool_name == "nmap":
+                        xml_path = res[0].data.get("xml")
+                        if xml_path:
+                            summary["open_ports"] += _count_nmap_ports(xml_path)
+                    else:
+                        json_path = res[0].data.get("report")
+                        if json_path:
+                            summary["ssl_issues"] += _count_testssl_issues(json_path)
             else:
                 findings.extend(tool_cls().run(target))
         except Exception as exc:  # noqa: BLE001
             logger.error("%s error: %s", tool_name, exc)
+
+    if show_summary:
+        _print_summary(summary)
 
     return findings
 
@@ -119,6 +192,11 @@ def cli() -> None:
         action="store_true",
         help="Chain tool output into the next module",
     )
+    parser.add_argument(
+        "--no-summary",
+        action="store_true",
+        help="Suppress final summary table",
+    )
     args = parser.parse_args()
 
     logger.info("🎯 Target: %s", args.target)
@@ -130,7 +208,12 @@ def cli() -> None:
         logger.error("❌ %s", exc)
         raise SystemExit(1)
 
-    findings = pipeline(args.target, args.tools, use_pipeline=args.pipeline)
+    findings = pipeline(
+        args.target,
+        args.tools,
+        use_pipeline=args.pipeline,
+        show_summary=not args.no_summary,
+    )
     write_json(findings, args.out)
     if args.report == "html":
         write_html(findings, args.out)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -14,7 +14,7 @@ def test_lambda_handler(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(
         lambda_function,
         "pipeline",
-        lambda target, tools, use_pipeline=False: [],
+        lambda target, tools, use_pipeline=False, show_summary=False: [],
     )
     monkeypatch.setattr(
         lambda_function,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -30,3 +30,58 @@ def test_pipeline(monkeypatch):
     results = pipeline('example.com', ['subfinder', 'httpx'], use_pipeline=True)
     assert captured['input'] == 'a.example'
     assert len(results) == 2
+
+
+def test_summary(monkeypatch, tmp_path: Path):
+    from modules.base import Module, Finding
+    import importlib
+    import main
+    importlib.reload(main)
+    monkeypatch.setattr(Module, 'registry', {})
+    monkeypatch.setattr(main.Module, 'registry', Module.registry)
+
+    summary_data = {}
+    monkeypatch.setattr(main, '_print_summary', lambda s: summary_data.update(s))
+
+    class Sub(Module):
+        name = 'subfinder'
+        def run(self, target: str):
+            return [Finding(tool=self.name, data={'host': 'a.example'})]
+
+    class Http(Module):
+        name = 'httpx'
+        def run(self, target: str):
+            return [Finding(tool=self.name, data={'url': f'https://{target}', 'host': target})]
+
+    class Nuc(Module):
+        name = 'nuclei'
+        def run(self, target: str):
+            return [Finding(tool=self.name, data={'id': 'x'})]
+
+    class Nm(Module):
+        name = 'nmap'
+        def run(self, target: str):
+            p = tmp_path / 'out.xml'
+            xml = (
+                '<nmaprun><host><ports><port><state state="open"/></port>'
+                '</ports></host></nmaprun>'
+            )
+            p.write_text(xml)
+            return [Finding(tool=self.name, data={'xml': str(p)})]
+
+    class Tssl(Module):
+        name = 'testssl'
+        def run(self, target: str):
+            p = tmp_path / 'out.json'
+            p.write_text('[{"severity":"WARN"}]')
+            return [Finding(tool=self.name, data={'report': str(p)})]
+
+    tools = ['subfinder', 'httpx', 'nuclei', 'nmap', 'testssl']
+    pipeline('example.com', tools, use_pipeline=True, show_summary=True)
+    assert summary_data == {
+        'subdomains': 1,
+        'live_hosts': 1,
+        'nuclei': 1,
+        'open_ports': 1,
+        'ssl_issues': 1,
+    }


### PR DESCRIPTION
## Summary
- show aggregated stats after pipeline execution
- support `--no-summary` CLI flag
- ensure AWS Lambda handler disables summary output
- test summary stats and lambda handler

## Testing
- `ruff check .`
- `pytest -q`
