### PR TITLE
Add multi-target CLI support

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -10,7 +10,7 @@ from utils.deps import check_dependencies, DependencyError
 import requests
 from utils.logger import get_logger
 from utils.notify import notify_slack, notify_teams
-from utils.output import write_html, write_json, write_pdf
+from utils.output import write_html, write_json, write_pdf, safe_filename_component
 from utils.plugins import load_plugins
 from main import pipeline
 
@@ -49,12 +49,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         raise RuntimeError(str(exc))
 
     findings = pipeline(target, tools, use_pipeline=pipeline_mode, show_summary=False)
-    json_path = write_json(findings, out_dir)
+    prefix = safe_filename_component(target)
+    json_path = write_json(findings, out_dir, prefix=prefix)
 
     if report == "html":
-        write_html(findings, out_dir)
+        write_html(findings, out_dir, prefix=prefix)
     elif report == "pdf":
-        write_pdf(findings, out_dir)
+        write_pdf(findings, out_dir, prefix=prefix)
 
     if webhook:
         try:

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import List
+from concurrent.futures import ThreadPoolExecutor
 import json
 import xml.etree.ElementTree as ET
 
@@ -23,7 +24,7 @@ from modules.base import Module, Finding
 import modules  # noqa: F401  # populate Module.registry
 import requests
 from utils.logger import get_logger
-from utils.output import write_json, write_html, write_pdf
+from utils.output import write_json, write_html, write_pdf, safe_filename_component
 from utils.notify import notify_slack, notify_teams
 from utils.deps import DependencyError, check_dependencies
 from utils.plugins import load_plugins
@@ -141,11 +142,35 @@ def pipeline(
     return findings
 
 
+def _collect_targets(args: argparse.Namespace) -> List[str]:
+    targets: List[str] = []
+    if getattr(args, "target_opt", None):
+        targets.extend(t.strip() for t in args.target_opt.split(",") if t.strip())
+    if getattr(args, "targets_file", None):
+        lines = Path(args.targets_file).read_text().splitlines()
+        targets.extend(t.strip() for t in lines if t.strip())
+    if getattr(args, "target", None):
+        targets.extend(t.strip() for t in args.target.split(",") if t.strip())
+    if not targets:
+        raise SystemExit("No target specified")
+    return targets
+
+
 def cli() -> None:
     parser = argparse.ArgumentParser(
         description="🛡️ Pentest-Toolkit – modular recon pipeline"
     )
-    parser.add_argument("target", help="Target domain / IP")
+    parser.add_argument("target", nargs="?", help="Target domain / IP")
+    parser.add_argument(
+        "--target",
+        dest="target_opt",
+        help="Target or comma-separated list of targets",
+    )
+    parser.add_argument(
+        "--targets-file",
+        type=Path,
+        help="File containing targets (one per line)",
+    )
     parser.add_argument(
         "--tools",
         nargs="+",
@@ -193,13 +218,19 @@ def cli() -> None:
         help="Chain tool output into the next module",
     )
     parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run scans for multiple targets concurrently",
+    )
+    parser.add_argument(
         "--no-summary",
         action="store_true",
         help="Suppress final summary table",
     )
     args = parser.parse_args()
 
-    logger.info("🎯 Target: %s", args.target)
+    targets = _collect_targets(args)
+    logger.info("🎯 Targets: %s", ", ".join(targets))
     logger.info("🧰 Tools : %s", ", ".join(args.tools))
 
     try:
@@ -208,29 +239,47 @@ def cli() -> None:
         logger.error("❌ %s", exc)
         raise SystemExit(1)
 
-    findings = pipeline(
-        args.target,
-        args.tools,
-        use_pipeline=args.pipeline,
-        show_summary=not args.no_summary,
+    all_findings: List[Finding] = []
+
+    def run_one(t: str) -> List[Finding]:
+        logger.info("▶️ %s", t)
+        res = pipeline(
+            t,
+            args.tools,
+            use_pipeline=args.pipeline,
+            show_summary=not args.no_summary,
+        )
+        prefix = safe_filename_component(t)
+        write_json(res, args.out, prefix=prefix)
+        if args.report == "html":
+            write_html(res, args.out, prefix=prefix)
+        elif args.report == "pdf":
+            write_pdf(res, args.out, prefix=prefix)
+
+        if args.webhook:
+            try:
+                if args.webhook_type == "slack":
+                    notify_slack(res, args.webhook, strict=args.strict_webhook)
+                else:
+                    notify_teams(res, args.webhook, strict=args.strict_webhook)
+            except requests.RequestException as exc:
+                logger.error("❌ Webhook error: %s", exc)
+                if args.strict_webhook:
+                    raise SystemExit(1)
+        logger.info("✅ Finished %s – %s findings", t, len(res))
+        return res
+
+    if args.parallel and len(targets) > 1:
+        with ThreadPoolExecutor() as pool:
+            for res in pool.map(run_one, targets):
+                all_findings.extend(res)
+    else:
+        for t in targets:
+            all_findings.extend(run_one(t))
+
+    logger.info(
+        "✅ Completed %s targets – %s findings collected", len(targets), len(all_findings)
     )
-    write_json(findings, args.out)
-    if args.report == "html":
-        write_html(findings, args.out)
-    elif args.report == "pdf":
-        write_pdf(findings, args.out)
-
-    if args.webhook:
-        try:
-            if args.webhook_type == "slack":
-                notify_slack(findings, args.webhook, strict=args.strict_webhook)
-            else:
-                notify_teams(findings, args.webhook, strict=args.strict_webhook)
-        except requests.RequestException as exc:
-            logger.error("❌ Webhook error: %s", exc)
-            raise SystemExit(1)
-
-    logger.info("✅ Finished – %s findings collected", len(findings))
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -19,7 +19,7 @@ def test_lambda_handler(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(
         lambda_function,
         "write_json",
-        lambda f, o: tmp_path / "out.json",
+        lambda f, o, prefix=None: tmp_path / "out.json",
     )
     result = lambda_function.lambda_handler(event, None)
     assert result["count"] == 0

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,3 +18,9 @@ def test_write_json(tmp_path: Path):
     assert path.suffix == ".json"
     data = json.loads(path.read_text())
     assert data[0]["foo"] == "bar"
+
+
+def test_write_json_prefix(tmp_path: Path):
+    path = write_json(_sample(), tmp_path, prefix="test")
+    assert path.exists()
+    assert "test" in path.stem

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -15,9 +15,15 @@ def test_write_html(tmp_path: Path):
     assert path.suffix == ".html"
 
 
+def test_write_html_prefix(tmp_path: Path):
+    path = write_html(_sample(), tmp_path, prefix="abc")
+    assert path.exists()
+    assert "abc" in path.stem
+
+
 def test_write_pdf(tmp_path: Path):
     try:
-        path = write_pdf(_sample(), tmp_path)
+        path = write_pdf(_sample(), tmp_path, prefix="xyz")
     except Exception as exc:  # pragma: no cover - environment may lack deps
         pytest.skip(f"pdf generation failed: {exc}")
     assert path.exists()

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,22 @@
+from argparse import Namespace
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import _collect_targets
+
+
+def test_collect_targets(tmp_path: Path):
+    targets_file = tmp_path / "targets.txt"
+    targets_file.write_text("a.com\nb.com\n")
+
+    args = Namespace(target=None, target_opt="c.com,d.com", targets_file=str(targets_file))
+    result = _collect_targets(args)
+    assert result == ["c.com", "d.com", "a.com", "b.com"]
+
+
+def test_collect_targets_positional():
+    args = Namespace(target="e.com,f.com", target_opt=None, targets_file=None)
+    result = _collect_targets(args)
+    assert result == ["e.com", "f.com"]

--- a/utils/output.py
+++ b/utils/output.py
@@ -24,9 +24,17 @@ def safe_filename_component(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "_", value)
 
 
-def write_json(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
+def write_json(
+    findings: List[Finding],
+    out_dir: Path = Path("output"),
+    *,
+    prefix: str | None = None,
+) -> Path:
     out_dir.mkdir(exist_ok=True)
-    name = f"results_{timestamp()}.json"
+    name = "results_{}{}.json".format(
+        f"{safe_filename_component(prefix)}_" if prefix else "",
+        timestamp(),
+    )
     path = out_dir / name
 
     tmp = path.with_suffix(".tmp")
@@ -69,9 +77,17 @@ def _html_template(findings: List[Finding]) -> str:
 """
 
 
-def write_html(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
+def write_html(
+    findings: List[Finding],
+    out_dir: Path = Path("output"),
+    *,
+    prefix: str | None = None,
+) -> Path:
     out_dir.mkdir(exist_ok=True)
-    name = f"report_{timestamp()}.html"
+    name = "report_{}{}.html".format(
+        f"{safe_filename_component(prefix)}_" if prefix else "",
+        timestamp(),
+    )
     path = out_dir / name
 
     tmp = path.with_suffix(".tmp")
@@ -82,8 +98,13 @@ def write_html(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
     return path
 
 
-def write_pdf(findings: List[Finding], out_dir: Path = Path("output")) -> Path:
-    html_path = write_html(findings, out_dir)
+def write_pdf(
+    findings: List[Finding],
+    out_dir: Path = Path("output"),
+    *,
+    prefix: str | None = None,
+) -> Path:
+    html_path = write_html(findings, out_dir, prefix=prefix)
     pdf_path = html_path.with_suffix(".pdf")
     HTML(filename=str(html_path)).write_pdf(str(pdf_path))
     logger.info("📄 PDF report -> %s", pdf_path)


### PR DESCRIPTION
## Summary
- support comma-separated targets and targets file
- process multiple targets sequentially or in parallel
- prefix result filenames with sanitized target
- update Lambda entrypoint for new output helpers
- test helper functions and output prefixes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688436f45154832a9f30d89abedc22c9