### PR TITLE
Add optional recon modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## Features
 
-* Wraps `subfinder`, `httpx`, `nuclei`, `nmap`, `testssl.sh` behind one interface
+* Wraps `subfinder`, `httpx`, `nuclei`, `nmap`, `testssl.sh`, optional modules like `dnsrecon`, `ffuf`, `screenshot`, `katana` behind one interface
 * Structured JSON output with optional HTML or PDF reports
 * Docker container and AWS Lambda compatible
 * Extensible plugin system for custom modules

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -3,6 +3,10 @@ from .httpx import Httpx
 from .nuclei import Nuclei
 from .nmap_ import Nmap
 from .testssl import TestSSL
+from .dnsrecon import Dnsrecon
+from .ffuf import Ffuf
+from .screenshot import Screenshot
+from .katana import Katana
 
 __all__ = [
     "Subfinder",
@@ -10,4 +14,8 @@ __all__ = [
     "Nuclei",
     "Nmap",
     "TestSSL",
+    "Dnsrecon",
+    "Ffuf",
+    "Screenshot",
+    "Katana",
 ]

--- a/modules/dnsrecon.py
+++ b/modules/dnsrecon.py
@@ -1,0 +1,46 @@
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List
+
+from utils.logger import get_logger
+from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
+
+logger = get_logger()
+
+
+class Dnsrecon(Module):
+    """DNS zone transfer checks using dnsrecon."""
+
+    name = "dnsrecon"
+    TIMEOUT = 120
+    input_types = ["domain"]
+
+    def run(self, target: str) -> List[Finding]:
+        logger.info("🔎 dnsrecon …")
+        out_dir = Path("output")
+        out_dir.mkdir(exist_ok=True)
+        safe = safe_filename_component(target)
+        out_file = out_dir / f"dnsrecon_{safe}_{timestamp()}.txt"
+        cmd = f"{self.bin('dnsrecon')} -d {shlex.quote(target)} -t axfr"
+        try:
+            proc = subprocess.run(
+                shlex.split(cmd),
+                capture_output=True,
+                text=True,
+                timeout=self.TIMEOUT,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"dnsrecon failed: {exc.stderr}")
+
+        out_file.write_text(proc.stdout)
+        records = [
+            Finding(self.name, {"record": line.strip()})
+            for line in proc.stdout.splitlines()
+            if line.strip()
+        ]
+        records.append(Finding(self.name, {"report": str(out_file)}))
+        logger.info("🔎 dnsrecon -> %s records", len(records) - 1)
+        return records

--- a/modules/ffuf.py
+++ b/modules/ffuf.py
@@ -1,0 +1,46 @@
+import json
+import shlex
+import subprocess
+from pathlib import Path
+import os
+from typing import List
+
+from utils.logger import get_logger
+from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
+
+logger = get_logger()
+
+
+class Ffuf(Module):
+    """Directory brute-forcing using ffuf."""
+
+    name = "ffuf"
+    TIMEOUT = 600
+    input_types = ["url"]
+    WORDLIST = Path(
+        os.environ.get(
+            "FFUF_WORDLIST", "/usr/share/seclists/Discovery/Web-Content/common.txt"
+        )
+    )
+
+    def run(self, target: str) -> List[Finding]:
+        logger.info("🗂️ ffuf …")
+        out_dir = Path("output")
+        out_dir.mkdir(exist_ok=True)
+        safe = safe_filename_component(target)
+        out_file = out_dir / f"ffuf_{safe}_{timestamp()}.json"
+        cmd = (
+            f"{self.bin('ffuf')} -u {shlex.quote(target.rstrip('/'))}/FUZZ "
+            f"-w {shlex.quote(str(self.WORDLIST))} -of json -o {out_file}"
+        )
+        try:
+            subprocess.run(shlex.split(cmd), check=True, timeout=self.TIMEOUT)
+        except subprocess.CalledProcessError:
+            raise RuntimeError("ffuf failed")
+
+        data = json.loads(out_file.read_text()).get("results", [])
+        findings = [Finding(self.name, r) for r in data]
+        findings.append(Finding(self.name, {"report": str(out_file)}))
+        logger.info("🗂️ ffuf -> %s entries", len(data))
+        return findings

--- a/modules/katana.py
+++ b/modules/katana.py
@@ -1,0 +1,44 @@
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List
+
+from utils.logger import get_logger
+from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
+
+logger = get_logger()
+
+
+class Katana(Module):
+    """Endpoint crawler using katana."""
+
+    name = "katana"
+    TIMEOUT = 300
+    input_types = ["url"]
+
+    def run(self, target: str) -> List[Finding]:
+        logger.info("🕷️ katana …")
+        out_dir = Path("output")
+        out_dir.mkdir(exist_ok=True)
+        safe = safe_filename_component(target)
+        out_file = out_dir / f"katana_{safe}_{timestamp()}.json"
+        cmd = f"{self.bin('katana')} -u {shlex.quote(target)} -json -o {out_file}"
+        try:
+            subprocess.run(shlex.split(cmd), check=True, timeout=self.TIMEOUT)
+        except subprocess.CalledProcessError:
+            raise RuntimeError("katana failed")
+
+        findings: List[Finding] = []
+        for line in out_file.read_text().splitlines():
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            findings.append(Finding(self.name, data))
+        findings.append(Finding(self.name, {"report": str(out_file)}))
+        logger.info("🕷️ katana -> %s entries", len(findings) - 1)
+        return findings

--- a/modules/screenshot.py
+++ b/modules/screenshot.py
@@ -1,0 +1,36 @@
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List
+
+from utils.logger import get_logger
+from modules.base import Module, Finding
+from utils.output import timestamp, safe_filename_component
+
+logger = get_logger()
+
+
+class Screenshot(Module):
+    """Capture webpage screenshots using headless Chrome."""
+
+    name = "screenshot"
+    TIMEOUT = 120
+    input_types = ["url"]
+
+    def run(self, target: str) -> List[Finding]:
+        logger.info("📸 screenshot …")
+        out_dir = Path("output")
+        out_dir.mkdir(exist_ok=True)
+        safe = safe_filename_component(target)
+        out_file = out_dir / f"screenshot_{safe}_{timestamp()}.png"
+        cmd = (
+            f"{self.bin('google-chrome')} --headless --disable-gpu "
+            f"--screenshot={out_file} --window-size=1280,1024 {shlex.quote(target)}"
+        )
+        try:
+            subprocess.run(shlex.split(cmd), check=True, timeout=self.TIMEOUT)
+        except subprocess.CalledProcessError:
+            raise RuntimeError("screenshot failed")
+
+        logger.info("📸 screenshot -> %s", out_file)
+        return [Finding(self.name, {"image": str(out_file)})]

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -10,6 +10,10 @@ import modules.nmap_ as nmap_
 import modules.testssl as testssl
 import modules.nuclei as nuclei
 
+import modules.dnsrecon as dnsrecon
+import modules.ffuf as ffuf
+import modules.screenshot as screenshot
+import modules.katana as katana
 
 class DummyProc:
     def __init__(self, stdout=""):
@@ -79,3 +83,62 @@ def test_nuclei(monkeypatch):
     monkeypatch.setattr(nuclei.subprocess, "run", fake_run)
     results = nuclei.Nuclei().run("example.com")
     assert results[0].data["templateID"] == "cve-2023-0000"
+
+def test_dnsrecon(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dnsrecon, "timestamp", lambda: "20240101-0000")
+    output = "example.com.\tIN\tA\t1.1.1.1\n"
+
+    def fake_run(*args, **kwargs):
+        return DummyProc(stdout=output)
+
+    monkeypatch.setattr(dnsrecon.subprocess, "run", fake_run)
+    results = dnsrecon.Dnsrecon().run("example.com")
+    assert results[0].data["record"].startswith("example.com")
+    assert Path(results[-1].data["report"]).exists()
+
+
+def test_ffuf(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ffuf, "timestamp", lambda: "20240101-0000")
+
+    def fake_run(*a, **kw):
+        out_file = Path("output/ffuf_http___example.com_20240101-0000.json")
+        out_file.parent.mkdir(exist_ok=True)
+        out_file.write_text(json.dumps({"results": [{"url": "http://example.com/admin",
+"status": 200}]}))
+        return DummyProc()
+
+    monkeypatch.setattr(ffuf.subprocess, "run", fake_run)
+    results = ffuf.Ffuf().run("http://example.com")
+    assert results[0].data["url"] == "http://example.com/admin"
+
+
+def test_screenshot(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(screenshot, "timestamp", lambda: "20240101-0000")
+
+    def fake_run(*a, **kw):
+        out_file = Path("output/screenshot_http___example.com_20240101-0000.png")
+        out_file.parent.mkdir(exist_ok=True)
+        out_file.touch()
+        return DummyProc()
+
+    monkeypatch.setattr(screenshot.subprocess, "run", fake_run)
+    results = screenshot.Screenshot().run("http://example.com")
+    assert Path(results[0].data["image"]).exists()
+
+
+def test_katana(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(katana, "timestamp", lambda: "20240101-0000")
+
+    def fake_run(*a, **kw):
+        out_file = Path("output/katana_http___example.com_20240101-0000.json")
+        out_file.parent.mkdir(exist_ok=True)
+        out_file.write_text('{"url": "http://example.com/api"}\n')
+        return DummyProc()
+
+    monkeypatch.setattr(katana.subprocess, "run", fake_run)
+    results = katana.Katana().run("http://example.com")
+    assert results[0].data["url"] == "http://example.com/api"


### PR DESCRIPTION
## Summary
- add new reconnaissance modules: dnsrecon, ffuf, screenshot and katana
- register new modules so CLI can discover them
- document new tools in README
- expand unit tests for the additional modules

## Testing
- `ruff check .`
- `pytest -q`
